### PR TITLE
ローカル環境だけのモック認証認可を現場のプロジェクトに沿って作る

### DIFF
--- a/apps/be-app/.env.example
+++ b/apps/be-app/.env.example
@@ -2,6 +2,8 @@ API_HOST=0.0.0.0
 API_PORT=8000
 DEBUG=false
 # Comma-separated origins (Next.js default: http://localhost:3000)
-CORS_ORIGINS=http://localhost:3000
+CORS_ORIGINS=["http://localhost:3000"]  
 # Optional: path to todos JSON (default: <be-app>/data/todos.json)
 # TODO_DATA_PATH=/absolute/path/to/todos.json
+# ローカル開発でモック認証を有効にする（現在は常に mock のため参考値）
+MOCK_AUTH=true

--- a/apps/be-app/README.md
+++ b/apps/be-app/README.md
@@ -44,9 +44,37 @@ pnpm dev
 | メソッド | パス | 説明 |
 |----------|------|------|
 | GET | `/health` | ヘルスチェック（例: `{"status":"ok"}`） |
-| GET | `/todos` | Todo 一覧（`{"todos": ["...", ...]}`） |
+| GET | `/me` | ログイン中ユーザー（要認証。`{"id","email","role"}`。`role` はロール未推論時 `null`） |
+| GET | `/todos` | Todo 一覧（要認証・要ロール。`{"todos": ["...", ...]}`） |
 
 OpenAPI ドキュメント: サーバ起動後 http://localhost:8000/docs
+
+## 認証・認可・ロール（バックエンドの責務）
+
+本リポジトリの be-app は **ローカル開発向けのモック認証**です。本番向けの IdP 連携や JWT 検証は行いません。
+
+### 認証（誰としてリクエストしているか）
+
+- **`private_router` にぶら下がるルート**（`/me`, `/todos`）は、[`src/adapter/web/routers.py`](src/adapter/web/routers.py) の **`auth_dependency`** が先に実行されます。
+- クライアントは **`Authorization: Bearer <トークン>`** を送ります。この **トークン文字列を「外部ユーザー ID」** とみなし、[`data/mock_users.json`](data/mock_users.json) の **`external_user_id`** と **完全一致**でユーザーを解決します（[`MockUserFileGateway`](src/adapter/gateways/mock_user_file_gateway.py)）。
+- 解決に成功すると [`MockAuthUseCase`](src/application/usecases/auth.py) が **`Principal`**（`user_id` は JSON の内部 `id`、`email`、**`roles`**）を組み立て、[`PrincipalContext`](src/common/context.py) に保存します。解決できない場合は **401**（`UnauthenticatedError`）です。
+
+### ロール（何の権限として振る舞うか）
+
+- ロールは **DB ではなく Bearer トークン文字列に対するキーワード部分一致**で推論されます（`student` / `受講者` → `STUDENT` 等）。いずれにも当たらない場合は **`roles` は空配列**です（[`Role`](src/common/roles.py) は `admin` / `teacher` / `student` / `hr` の値を持つ列挙）。
+- **`/me` のレスポンス `role`** は、推論結果の **先頭ロールの value** を返し、**ロールが無いときは `null`** です（暗黙のデフォルトロールは付けません）。
+
+### 認可（そのルートにアクセスしていいか）
+
+- [`require_role`](src/adapter/web/middleware/auth.py) は、**`PrincipalContext` に入っている `principal.roles` のいずれかが、許可リストに含まれるか**を見ます。含まれなければ **403**（`ForbiddenError`）です。
+- 現状 **`/todos`** は **`list(Role)`**（定義済みの全ロール）を許可にしており、**`roles` が空のユーザーは `/me` には届いても `/todos` では拒否**されます。
+
+### 設定・DI との関係（ざっくり）
+
+- **`mock_users_path`**（[`config.py`](src/config.py)）でモックユーザ JSON の場所を指定し、[`main.py`](src/main.py) の **`from_dict`** で DI コンテナの **`Gateways`** に渡し、**`MockUserFileGateway`** がそのパスを開きます。
+- **`MockAuthUseCase`** はコンテナ経由で **`app.state.auth_usecase`** に載せ、上記 **`auth_dependency`** が毎リクエストそれを `execute` します。
+
+フロント側でトークンをどう保持するか・画面でどう扱うかは **fe-app の README** を参照してください。
 
 ## 環境変数
 
@@ -57,8 +85,9 @@ OpenAPI ドキュメント: サーバ起動後 http://localhost:8000/docs
 | `API_HOST` | 既定 `0.0.0.0` |
 | `API_PORT` | 既定 `8000`（アプリ設定。uvicorn の CLI と揃える場合は起動オプションも合わせる） |
 | `DEBUG` | FastAPI の `debug` に反映 |
-| `CORS_ORIGINS` | カンマ区切り（例: `http://localhost:3000,http://127.0.0.1:3000`） |
+| `CORS_ORIGINS` | 許可オリジン。`list[str]` 用のため **JSON 配列**推奨（例: `["http://localhost:3000"]`）。空だと CORS が効かない場合があります |
 | `TODO_DATA_PATH` | 任意。Todo 一覧の JSON ファイルパス。未指定時は `data/todos.json`（`be-app` 直下） |
+| `MOCK_USERS_PATH` | 任意。モックユーザ一覧 JSON。未指定時は `data/mock_users.json` |
 
 ## ディレクトリ構成
 
@@ -67,24 +96,31 @@ OpenAPI ドキュメント: サーバ起動後 http://localhost:8000/docs
 ```
 apps/be-app/
 ├── data/
-│   └── todos.json              # Todo 一覧のデータ（JSON 配列 of 文字列）
+│   ├── todos.json              # Todo 一覧のデータ（JSON 配列 of 文字列）
+│   └── mock_users.json         # モック認証用ユーザー（external_user_id / id / email）
 ├── src/
-│   ├── main.py                 # FastAPI アプリ・CORS・ルート、DI の wire
+│   ├── main.py                 # FastAPI アプリ・CORS・ルート、DI の wire・app.state.auth
 │   ├── config.py               # pydantic-settings（.env）
+│   ├── common/                 # ロール・Principal・共通エラー
+│   ├── enterprise/entities/    # User 等のドメインエンティティ
 │   ├── application/            # アプリケーション層（フレームワーク非依存の意図）
 │   │   ├── gateways/
-│   │   │   └── i_todo_gateway.py   # Todo 用ポート（Protocol）
+│   │   │   ├── i_todo_gateway.py
+│   │   │   └── i_user_gateway.py   # モック認証用ユーザー解決ポート
 │   │   └── usecases/
+│   │       ├── auth.py             # MockAuthUseCase
 │   │       └── todo/
 │   │           └── list_todos.py   # 一覧取得ユースケース
 │   └── adapter/                # アダプター層（外部I/O・DI・Webスキーマ）
 │       ├── di/
 │       │   └── container.py    # dependency_injector（Gateways / UseCases）
 │       ├── gateways/
-│       │   └── todo_file_gateway.py  # JSON ファイルから Todo を読む実装
+│       │   ├── todo_file_gateway.py
+│       │   └── mock_user_file_gateway.py
 │       └── web/
-│           └── schemas/
-│               └── todo.py     # レスポンス用 Pydantic モデル等
+│           ├── routers.py      # auth_dependency・public/private ルータ
+│           ├── middleware/
+│           └── schemas/          # todo / user 等のレスポンスモデル
 ├── .env.example
 ├── pyproject.toml
 ├── uv.lock

--- a/apps/be-app/data/mock_users.json
+++ b/apps/be-app/data/mock_users.json
@@ -1,0 +1,27 @@
+[
+  {
+    "external_user_id": "teacher-dev-1",
+    "id": "550e8400-e29b-41d4-a716-446655440001",
+    "email": "teacher1@local.example.com"
+  },
+  {
+    "external_user_id": "student-dev-1",
+    "id": "550e8400-e29b-41d4-a716-446655440002",
+    "email": "student1@local.example.com"
+  },
+  {
+    "external_user_id": "hr-contact-1",
+    "id": "550e8400-e29b-41d4-a716-446655440003",
+    "email": "hr1@local.example.com"
+  },
+  {
+    "external_user_id": "運営-admin-1",
+    "id": "550e8400-e29b-41d4-a716-446655440004",
+    "email": "admin1@local.example.com"
+  },
+  {
+    "external_user_id": "plain-dev-1",
+    "id": "550e8400-e29b-41d4-a716-446655440005",
+    "email": "plain1@local.example.com"
+  }
+]

--- a/apps/be-app/src/adapter/di/container.py
+++ b/apps/be-app/src/adapter/di/container.py
@@ -1,20 +1,43 @@
+"""依存の組み立て（DI）。
+
+設定（パスなど）はConfigurationの穴にmainから流し込み、
+Gatewaysで「外の世界」、UseCasesでアプリの手続きを生成する。
+"""
+
 from dependency_injector import containers, providers
 
+from src.adapter.gateways.mock_user_file_gateway import MockUserFileGateway
 from src.adapter.gateways.todo_file_gateway import TodoFileGateway
+from src.application.usecases.auth import MockAuthUseCase
 from src.application.usecases.todo.list_todos import ListTodosUseCase
 
 
 class Gateways(containers.DeclarativeContainer):
+    # main.pyで定義したSettings(config.py)を取得
     config = providers.Configuration()
 
     todo = providers.Factory(
         TodoFileGateway,
+        # main.pyで定義した_container.config.from_dictでtodo_data_pathを注入している
         file_path=config.todo_data_path,
+    )
+
+    # IUserGatewayの実装：mock_users_pathのJSONをexternal_user_idで引く（アプリで1つでよいのでSingleton）
+    user = providers.Singleton(
+        MockUserFileGateway,
+        file_path=config.mock_users_path,
     )
 
 
 class UseCases(containers.DeclarativeContainer):
+    # 親Containerから渡されるGatewaysコンテナ（todo/userなど）
     gateways = providers.DependenciesContainer()
+
+    # 認証ユースケースにIUserGatewayを外から渡す（newせずコンテナが依存を解決する）
+    auth = providers.Singleton(
+        MockAuthUseCase,
+        user_entity_gateway=gateways.user,
+    )
 
     list_todos = providers.Factory(
         ListTodosUseCase,
@@ -23,6 +46,7 @@ class UseCases(containers.DeclarativeContainer):
 
 
 class Container(containers.DeclarativeContainer):
+    # main.pyで定義したSettings(config.py)を取得
     config = providers.Configuration()
 
     gateways = providers.Container(

--- a/apps/be-app/src/adapter/gateways/mock_user_file_gateway.py
+++ b/apps/be-app/src/adapter/gateways/mock_user_file_gateway.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from src.application.gateways.i_user_gateway import IUserGateway
+from src.enterprise.entities.user import User
+
+
+class MockUserFileGateway(IUserGateway):
+    """ローカル開発用: JSON の external_user_id と Bearer トークンを突き合わせる。"""
+
+    def __init__(self, file_path: Path) -> None:
+        self._file_path = file_path
+
+    async def find_by_user_id(self, user_id: str) -> User | None:
+        if not self._file_path.is_file():
+            return None
+        with self._file_path.open(encoding="utf-8") as f:
+            users_data = json.load(f)
+        if not isinstance(users_data, list):
+            raise ValueError("mock users data must be a JSON array")
+        for user_entry in users_data:
+            if not isinstance(user_entry, dict):
+                continue
+            external_user_id = user_entry.get("external_user_id")
+            if external_user_id != user_id:
+                continue
+            uid = user_entry.get("id")
+            email = user_entry.get("email")
+            if not isinstance(uid, str) or not isinstance(email, str):
+                raise ValueError("mock user entry requires string id and email")
+            return User(id=uid, email=email)
+        return None
+   

--- a/apps/be-app/src/adapter/web/error_mapping.py
+++ b/apps/be-app/src/adapter/web/error_mapping.py
@@ -1,0 +1,75 @@
+"""ドメインエラーと HTTP レスポンスのマッピング"""
+
+from pydantic import BaseModel
+from starlette.status import (
+    HTTP_400_BAD_REQUEST,
+    HTTP_401_UNAUTHORIZED,
+    HTTP_403_FORBIDDEN,
+    HTTP_409_CONFLICT,
+    HTTP_500_INTERNAL_SERVER_ERROR,
+)
+
+from src.common.errors import (
+    BadRequestError,
+    ConflictError,
+    DomainError,
+    ForbiddenError,
+    UnauthenticatedError,
+    ValidationError,
+)
+
+
+class ErrorResponse(BaseModel):
+    """エラーレスポンスのスキーマ"""
+
+    error_code: str
+    message: str
+
+
+def map_error_to_response(error: Exception) -> tuple[int, ErrorResponse]:
+    """エラーを対応するステータスコードとエラーレスポンスに変換する。
+
+    Args:
+        error: 変換対象のエラー
+
+    Returns:
+        ステータスコードとエラーレスポンスのタプル
+    """
+    if isinstance(error, BadRequestError):
+        return (
+            HTTP_400_BAD_REQUEST,
+            ErrorResponse(error_code=error.error_code, message=error.message),
+        )
+    if isinstance(error, ValidationError):
+        return (
+            HTTP_400_BAD_REQUEST,
+            ErrorResponse(error_code=error.error_code, message=error.message),
+        )
+    if isinstance(error, UnauthenticatedError):
+        return (
+            HTTP_401_UNAUTHORIZED,
+            ErrorResponse(error_code=error.error_code, message=error.message),
+        )
+    if isinstance(error, ForbiddenError):
+        return (
+            HTTP_403_FORBIDDEN,
+            ErrorResponse(error_code=error.error_code, message=error.message),
+        )
+    if isinstance(error, ConflictError):
+        return (
+            HTTP_409_CONFLICT,
+            ErrorResponse(error_code=error.error_code, message=error.message),
+        )
+    if isinstance(error, DomainError):
+        return (
+            HTTP_500_INTERNAL_SERVER_ERROR,
+            ErrorResponse(error_code=error.error_code, message=error.message),
+        )
+    return (
+        HTTP_500_INTERNAL_SERVER_ERROR,
+        ErrorResponse(
+            error_code="internal_server_error",
+            message="Internal server error occurred",
+        ),
+    )
+    

--- a/apps/be-app/src/adapter/web/exception_handlers.py
+++ b/apps/be-app/src/adapter/web/exception_handlers.py
@@ -1,0 +1,18 @@
+"""FastAPI アプリケーションの例外ハンドラ登録"""
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from src.adapter.web.error_mapping import map_error_to_response
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """ドメインエラー等を JSON レスポンスに変換するハンドラを登録する。"""
+
+    @app.exception_handler(Exception)
+    async def handle_exceptions(_request: Request, exc: Exception) -> JSONResponse:
+        status_code, error_response = map_error_to_response(exc)
+        return JSONResponse(
+            status_code=status_code,
+            content=error_response.model_dump(),
+        )

--- a/apps/be-app/src/adapter/web/fastapi.py
+++ b/apps/be-app/src/adapter/web/fastapi.py
@@ -1,0 +1,14 @@
+"""FastAPI アプリケーションの初期化"""
+
+from fastapi import FastAPI
+
+from src.adapter.web.exception_handlers import register_exception_handlers
+from src.config import get_settings
+
+
+def create_app() -> FastAPI:
+    """FastAPI アプリケーションを生成し、例外ハンドラ等を登録する。"""
+    settings = get_settings()
+    app = FastAPI(debug=settings.debug)
+    register_exception_handlers(app)
+    return app

--- a/apps/be-app/src/adapter/web/middleware/auth.py
+++ b/apps/be-app/src/adapter/web/middleware/auth.py
@@ -1,0 +1,31 @@
+"""ロールベースのアクセス制御デコレータ"""
+
+from functools import wraps
+
+from src.common.context import PrincipalContext
+from src.common.errors import ForbiddenError
+from src.common.roles import Role
+
+
+def require_role(allowed_roles: list[Role]):
+    """特定のロールを要求するデコレータ。
+
+    @private_router エンドポイントに @require_role([Role.ADMIN]) のように付与する。
+    auth_dependency で PrincipalContext が設定されていることが前提。
+    """
+
+    def decorator(f):
+        @wraps(f)
+        async def decorated_function(*args, **kwargs):
+            principal = PrincipalContext.get()
+            if principal is None:
+                raise ValueError("PrincipalContext が設定されていません")
+
+            if not any(role in principal.roles for role in allowed_roles):
+                raise ForbiddenError("アクセスが拒否されました: 権限が不足しています")
+
+            return await f(*args, **kwargs)
+
+        return decorated_function
+
+    return decorator

--- a/apps/be-app/src/adapter/web/routers.py
+++ b/apps/be-app/src/adapter/web/routers.py
@@ -1,0 +1,26 @@
+"""FastAPI ルーター定義"""
+
+from fastapi import APIRouter, Depends, Request
+
+from src.application.usecases.auth import AuthUseCaseInput, MockAuthUseCase
+from src.common.context import Principal, PrincipalContext
+
+
+async def auth_dependency(request: Request) -> Principal:
+    """認証チェックを行う Dependency。private_router に付与する。"""
+    auth_header = request.headers.get("Authorization")
+    usecase: MockAuthUseCase = request.app.state.auth_usecase
+
+    output = await usecase.execute(AuthUseCaseInput(header=auth_header))
+
+    principal = Principal(
+        user_id=output.user_id,
+        email=output.email,
+        roles=output.roles,
+    )
+    PrincipalContext.set(principal)
+    return principal
+
+
+public_router = APIRouter()
+private_router = APIRouter(dependencies=[Depends(auth_dependency)])

--- a/apps/be-app/src/adapter/web/schemas/user.py
+++ b/apps/be-app/src/adapter/web/schemas/user.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class MeResponse(BaseModel):
+    id: str
+    email: str
+    role: str | None

--- a/apps/be-app/src/application/gateways/i_user_gateway.py
+++ b/apps/be-app/src/application/gateways/i_user_gateway.py
@@ -1,0 +1,13 @@
+"""ユーザー永続化のポート"""
+
+from abc import ABC, abstractmethod
+
+from src.enterprise.entities.user import User
+
+
+class IUserGateway(ABC):
+    """Bearer トークン値（外部ユーザーID）でユーザーを検索する。"""
+
+    @abstractmethod
+    async def find_by_user_id(self, user_id: str) -> User | None:
+        pass

--- a/apps/be-app/src/application/usecases/auth.py
+++ b/apps/be-app/src/application/usecases/auth.py
@@ -1,0 +1,68 @@
+"""認証・認可ユースケース（ローカル Mock 用）"""
+
+from pydantic import BaseModel
+
+from src.application.gateways.i_user_gateway import IUserGateway
+from src.common.errors import UnauthenticatedError
+from src.common.roles import Role
+
+_ROLE_KEYWORDS: list[tuple[tuple[str, ...], Role]] = [
+    (("student", "受講者"), Role.STUDENT),
+    (("teacher", "講師"), Role.TEACHER),
+    (("admin", "運営"), Role.ADMIN),
+    (("hr", "人事"), Role.HR),
+]
+
+
+class AuthUseCaseInput(BaseModel):
+    header: str | None
+
+
+class AuthUseCaseOutput(BaseModel):
+    user_id: str
+    email: str
+    roles: list[Role]
+
+
+class MockAuthUseCase:
+    """ローカル開発専用の Mock 認証ユースケース。
+
+    Bearerトークンを外部ユーザーIDとしてIUserGateway で解決する。
+    トークン文字列に含まれるキーワードから業務ロールを推論し、未一致は roles=[]。
+    """
+
+    def __init__(self, user_entity_gateway: IUserGateway) -> None:
+        self.user_entity_gateway = user_entity_gateway
+
+    async def execute(self, input: AuthUseCaseInput) -> AuthUseCaseOutput:
+        if not input.header:
+            raise UnauthenticatedError("Authorization header is missing")
+
+        split_header = input.header.split(" ")
+        if len(split_header) != 2 or split_header[0] != "Bearer":
+            raise UnauthenticatedError("Invalid Authorization header format")
+
+        user_id_token = split_header[1]
+        if not user_id_token:
+            raise UnauthenticatedError("Token is empty")
+
+        roles = next(
+            (
+                [role]
+                for keywords, role in _ROLE_KEYWORDS
+                if any(kw in user_id_token for kw in keywords)
+            ),
+            [],
+        )
+
+        user = await self.user_entity_gateway.find_by_user_id(user_id_token)
+        if not user:
+            raise UnauthenticatedError(
+                f"ユーザーID {user_id_token} のユーザーが見つかりません"
+            )
+
+        return AuthUseCaseOutput(
+            user_id=str(user.id),
+            email=user.email,
+            roles=roles,
+        )

--- a/apps/be-app/src/common/context.py
+++ b/apps/be-app/src/common/context.py
@@ -1,0 +1,35 @@
+"""コンテキスト管理"""
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
+
+from src.common.roles import Role
+
+T = TypeVar("T")
+
+
+class _ContextManager(Generic[T]):
+    def __init__(self, name: str) -> None:
+        self._ctx: ContextVar[Optional[T]] = ContextVar(name, default=None)
+
+    def get(self) -> Optional[T]:
+        return self._ctx.get()
+
+    def set(self, value: T) -> Token[T]:
+        return self._ctx.set(value)
+
+    def reset(self, token: Token[T]) -> None:
+        self._ctx.reset(token)
+
+
+@dataclass
+class Principal:
+    """リクエストのセッション情報"""
+
+    user_id: str
+    email: str
+    roles: list[Role]
+
+
+PrincipalContext = _ContextManager[Principal]("principal_context")

--- a/apps/be-app/src/common/errors.py
+++ b/apps/be-app/src/common/errors.py
@@ -1,0 +1,41 @@
+"""ドメイン層で使用するエラー定義
+
+このモジュールでは、ドメイン層で使用される共通のエラークラスを定義します。
+各エラークラスは、特定のエラー状況を表現し、適切なエラーメッセージを提供します。
+"""
+
+class DomainError(Exception):
+    """ドメイン層で発生する一般的なエラーのベースクラス"""
+
+    def __init__(self, error_code: str, message: str) -> None:
+        """ドメイン層で発生する一般的なエラーのベースクラス
+
+        Args:
+            error_code: エラーを識別するコード
+            message: エラーの詳細メッセージ
+        """
+        self.error_code = error_code
+        self.message = message
+        super().__init__(message)
+
+
+class UnauthenticatedError(DomainError):
+    def __init__(self, message: str = "Unauthenticated") -> None:
+        super().__init__(error_code="unauthenticated", message=message)
+
+
+class ForbiddenError(DomainError):
+    def __init__(self, message: str = "Forbidden") -> None:
+        super().__init__(error_code="forbidden", message=message)
+
+class BadRequestError(DomainError):
+    def __init__(self, message: str) -> None:
+        super().__init__(error_code="bad_request", message=message)
+
+class ConflictError(DomainError):
+    def __init__(self, message: str) -> None:
+        super().__init__(error_code="conflict", message=message)
+
+class ValidationError(DomainError):
+    def __init__(self, message: str) -> None:
+        super().__init__(error_code="validation", message=message)

--- a/apps/be-app/src/common/roles.py
+++ b/apps/be-app/src/common/roles.py
@@ -1,0 +1,10 @@
+"""ロール定義"""
+
+from enum import Enum
+
+
+class Role(Enum):
+    ADMIN = "admin"
+    TEACHER = "teacher"
+    STUDENT = "student"
+    HR = "hr"

--- a/apps/be-app/src/config.py
+++ b/apps/be-app/src/config.py
@@ -4,7 +4,12 @@ from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _default_todo_data_path = Path(__file__).resolve().parent.parent / "data" / "todos.json"
-
+# モック認証で「Bearerのトークン＝external_user_id」と照合するユーザーの一覧JSON
+# 環境変数MOCK_USERS_PATHに別パスを書けば上書きされ、最終的にはmainがDIコンテナへ渡し、
+# MockUserFileGatewayがそのパスを開いて読む。
+_default_mock_users_path = (
+    Path(__file__).resolve().parent.parent / "data" / "mock_users.json"
+)
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
@@ -18,6 +23,10 @@ class Settings(BaseSettings):
     debug: bool = False
     cors_origins: list[str] = ["http://localhost:3000"]
     todo_data_path: Path = _default_todo_data_path
+    # mock_users_path はモックユーザJSONの場所を表す設定で、通常はデフォルトパスだが
+    # .envのMOCK_USERS_PATHで変えられ、ファイル下部のget_settings() で値が決まり、
+    # main経由でDIコンテナに渡され、認証時にMockUserFileGatewayがそのパスのファイルを読む
+    mock_users_path: Path = _default_mock_users_path
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/apps/be-app/src/enterprise/entities/user.py
+++ b/apps/be-app/src/enterprise/entities/user.py
@@ -1,0 +1,11 @@
+"""ユーザーエンティティ"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class User:
+    """モック認証で解決されるユーザー。"""
+
+    id: str
+    email: str

--- a/apps/be-app/src/main.py
+++ b/apps/be-app/src/main.py
@@ -1,15 +1,37 @@
 from dependency_injector.wiring import Provide, inject
-from fastapi import Depends, FastAPI
+from fastapi import Depends
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.adapter.di.container import Container
+from src.adapter.web.fastapi import create_app
+from src.adapter.web.middleware.auth import require_role
+from src.adapter.web.routers import private_router, public_router
 from src.adapter.web.schemas.todo import TodoListResponse
+from src.adapter.web.schemas.user import MeResponse
 from src.application.usecases.todo.list_todos import ListTodosUseCase
+from src.common.context import PrincipalContext
+from src.common.roles import Role
 from src.config import get_settings
 
+# 【設定とDIの流れ】mock_users_pathを例に（Mermaidのflowchartと同じつながり）
+#
+#   config.py
+#     .env/環境変数 ──→ pydantic-settingsがSettingsへ反映
+#     get_settings() ──→ 確定したSettingsインスタンスを返す
+#
+#   main.py（このファイル）
+#     settings=get_settings() ──→ 上記のSettingsを取得
+#     _container.config.from_dict({gateways:{mock_users_path:...}}) ──→ DIのGateways用Configurationへ注入
+#     _container.usecases.auth() ──→ ゲートウェイ注入済みのMockAuthUseCaseを取得（下でapp.stateへ）
+#
+#   container.py
+#     Gateways.user ──→ MockUserFileGateway(file_path=config.mock_users_path)
+#     （認証時にそのパスのmock_users.jsonを開く）
+#
+#   get_settings() ──→ settings ──→ from_dict ──→ Gateways.user ──→ MockUserFileGateway
 settings = get_settings()
 
-app = FastAPI(debug=settings.debug)
+app = create_app()
 
 app.add_middleware(
     CORSMiddleware,
@@ -19,29 +41,55 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Depends(Provide[usecases.list_todos])などで参照するためのエイリアス（コンテナのusecasesブロック）
 usecases = Container.usecases
 
 
-@app.get("/health")
+@public_router.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.get("/todos", response_model=TodoListResponse)
+@private_router.get("/me", response_model=MeResponse)
+async def get_me() -> MeResponse:
+    """ログイン中のユーザー情報を返す。"""
+    principal = PrincipalContext.get()
+    return MeResponse(
+        id=principal.user_id,
+        email=principal.email,
+        role=principal.roles[0].value if principal.roles else None,
+    )
+
+
+@private_router.get("/todos", response_model=TodoListResponse)
+@require_role(list(Role))
 @inject
-def get_todo_list(
+async def get_todo_list(
     list_todos_use_case: ListTodosUseCase = Depends(Provide[usecases.list_todos]),
 ) -> TodoListResponse:
     todos = list_todos_use_case.execute()
     return TodoListResponse(todos=todos)
 
 
+# container.pyのGatewaysが持つConfigurationの穴を埋める
 _container = Container()
+# Containerのconfig.gatewaysに対応
 _container.config.from_dict(
     {
         "gateways": {
             "todo_data_path": settings.todo_data_path,
+            "mock_users_path": settings.mock_users_path,
         },
     }
 )
+# このモジュール（main.py）内の Depends(Provide[usecases.list_todos])のようなwiringを有効にするためのdependency-injectorの手続き
+# このモジュールの中にある @inject と Provide[...] を、さきほど作ったコンテナとつなぐ。
 _container.wire(modules=[__name__])
+
+# 認証ユースケースを1つ用意してアプリ全体(app.state)で共有する。
+# MockAuthUseCaseは内部でユーザーを探すゲートウェイが必要なので、container.pyで定義したusecases.auth()でゲートウェイまで差し込んだインスタンスを返す。
+# 下の代入でFastAPIのapp.stateに載せ、routers.pyのauth_dependencyがrequest.app.stateから同じものを取って使う。
+app.state.auth_usecase = _container.usecases.auth()
+
+app.include_router(public_router)
+app.include_router(private_router)

--- a/apps/fe-app/README.md
+++ b/apps/fe-app/README.md
@@ -30,6 +30,39 @@ pnpm dev
 - API のベース URL は環境変数で渡すのが一般的です（例: `NEXT_PUBLIC_API_URL=http://localhost:8000` を `.env.local` に記載し、クライアントから `fetch` する）。
 - CORS は `be-app` 側の `CORS_ORIGINS` で調整します（開発時は `http://localhost:3000` が既定）。
 
+## 認証・認可・ロール（フロントの責務）
+
+fe-app は **ブラウザ側のモックログイン**であり、**トークンの発行やロールの真偽検証は行いません**。権限の判定は **be-app が HTTP ステータス（401 / 403）とレスポンスで返す結果に従う**形です。
+
+### トークンとセッション（[`src/lib/session-manager.ts`](src/lib/session-manager.ts)）
+
+- **ログインフォームの「ユーザー ID」**を、そのまま **Bearer トークン**として `localStorage` に保存します（キーは実装どおり `mock_auth_token` 等）。be-app ではこの文字列が **`data/mock_users.json` の `external_user_id` と一致する必要**があります。
+- **パスワード欄**は UI 上の必須チェック用であり、**API には送っていません**（ローカルモック用）。
+- 併せて表示用の **`id` / `email` / `role`** を `localStorage` に保存しますが、**信頼できる値はログイン成功後に `GET /me` で返ってきた内容で上書き**します。
+
+### API 呼び出し（[`src/lib/api-client.ts`](src/lib/api-client.ts)）
+
+- すべてのリクエストで **`Authorization: Bearer <上記トークン>`** を付与します。トークンが無い場合は **`UnauthenticatedError`** を投げ、呼び出し側で未ログイン扱いにできます。
+- **401** は `UnauthenticatedError`、**403** は `ForbiddenError` にマッピングします（例: ロール不足で `/todos` が拒否された場合）。
+- TanStack Query 利用箇所では [`src/lib/query-client-provider.tsx`](src/lib/query-client-provider.tsx) が **`UnauthenticatedError` → `/login`**、**`ForbiddenError` → `/forbidden`** のように共通で画面遷移します。`apiClient` を直接使うコードでは、呼び出し側で同様の処理が必要です。
+
+### ロール表示（[`src/lib/session-manager.ts`](src/lib/session-manager.ts) の型）
+
+- フロントの **`Role` 型**は be-app の **`Role` 列挙の value**（`admin` / `teacher` / `student` / `hr`）と揃えています。
+- **`/me` の `role` が `null`** のときは、トークンにロール用キーワードが無かった等の意味合いで、**クライアントでも `null` のまま保持**します（勝手にデフォルトロールを付けない）。
+
+### ログイン画面（[`src/app/login/page.tsx`](src/app/login/page.tsx)）
+
+1. フォームのユーザー ID で **仮の `SessionManager.setAuthentication`** を行い、続けて **`apiClient("/me")`** を呼びます（この時点で初めて be-app が Bearer を検証します）。
+2. 成功したら **`/me` の JSON** で `id` / `email` / `role` を **再保存**し、トークンキーは **引き続きフォームに入力した外部ユーザー ID** のままにします（Bearer は外部 ID のまま、表示用 `id` は be-app が返す内部 IDになり得ます）。
+
+### フロントが「やらない」こと
+
+- JWT の検証やロールの再計算、エンドポイントごとの RBAC の最終判断（**be-app の責務**）。
+- サーバが返したロールと矛盾する独自の管理者判定（モックの一貫性のため、表示はサーバ準拠に寄せています）。
+
+トークンの解釈・`Principal` の組み立て・`@require_role` による拒否は **be-app の README** を参照してください。
+
 ## 技術スタック
 
 - Next.js 16（App Router）

--- a/apps/fe-app/src/app/forbidden/page.tsx
+++ b/apps/fe-app/src/app/forbidden/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+
+export default function ForbiddenPage() {
+  return (
+    <div className="flex min-h-svh items-center justify-center px-6 py-12">
+      <main className="flex w-full max-w-[420px] flex-col gap-6 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+          アクセス権限がありません
+        </h1>
+        <p className="text-[15px] text-foreground/60">
+          このページを表示する権限がありません。
+        </p>
+        <Link
+          href="/"
+          className="flex items-center justify-center rounded-xl border border-black/[0.08] bg-foreground px-4 py-3 text-[15px] font-medium text-background transition-colors hover:bg-foreground/90 dark:border-white/[0.145]"
+        >
+          トップに戻る
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/apps/fe-app/src/app/layout.tsx
+++ b/apps/fe-app/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { TodoProvider } from "@/contexts/todo-context";
+import { SessionProvider } from "@/contexts/session-context";
+import { AppShell } from "@/components/app-shell";
 import { QueryClientProviderWrapper } from "@/lib/query-client-provider";
 
 const geistSans = Geist({
@@ -31,7 +33,11 @@ export default function RootLayout({
     >
       <body className="flex min-h-full flex-col font-sans">
         <QueryClientProviderWrapper>
-          <TodoProvider>{children}</TodoProvider>
+          <SessionProvider>
+            <TodoProvider>
+              <AppShell>{children}</AppShell>
+            </TodoProvider>
+          </SessionProvider>
         </QueryClientProviderWrapper>
       </body>
     </html>

--- a/apps/fe-app/src/app/login/page.tsx
+++ b/apps/fe-app/src/app/login/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useCallback, useEffect, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { SessionManager, type Role } from "@/lib/session-manager";
+import { apiClient } from "@/lib/api-client";
+
+type MeResponse = { id: string; email: string; role: string | null };
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (SessionManager.isSignedIn()) {
+      router.replace("/");
+    }
+  }, [router]);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      if (!userId || !password) {
+        setError("ユーザーIDとパスワードを入力してください");
+        return;
+      }
+
+      setLoading(true);
+      setError("");
+
+      try {
+        // 仮トークン（user_id そのもの）を localStorage に保存してから /me を叩く
+        SessionManager.setAuthentication(userId, {
+          id: userId,
+          email: `${userId}@local.example.com`,
+          role: null,
+        });
+
+        // バックエンドの /me でロールを確定させる
+        const me = await apiClient<MeResponse>("/me");
+
+        SessionManager.setAuthentication(userId, {
+          id: me.id,
+          email: me.email,
+          role: me.role as Role | null,
+        });
+
+        router.push("/");
+      } catch {
+        SessionManager.clearSession();
+        setError("ログインに失敗しました。ユーザーIDを確認してください。");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [userId, password, router],
+  );
+
+  return (
+    <div className="flex min-h-svh items-center justify-center px-6 py-12">
+      <main className="flex w-full max-w-[420px] flex-col gap-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+          ログイン
+        </h1>
+        <p className="text-[13px] text-foreground/50">
+          ローカル環境専用のモックログインです。ユーザーID は be-app の{" "}
+          <code className="rounded bg-black/[0.06] px-1 dark:bg-white/[0.08]">
+            data/mock_users.json
+          </code>{" "}
+          の <code className="rounded bg-black/[0.06] px-1 dark:bg-white/[0.08]">external_user_id</code>{" "}
+          と一致させてください（例: <code className="rounded bg-black/[0.06] px-1 dark:bg-white/[0.08]">teacher-dev-1</code>
+          ）。トークン文字列に teacher / student などが含まれるとロールが付きます。
+        </p>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="userId"
+              className="text-[14px] font-medium text-foreground"
+            >
+              ユーザーID
+            </label>
+            <input
+              id="userId"
+              type="text"
+              value={userId}
+              onChange={(e) => setUserId(e.target.value)}
+              placeholder="例: teacher-dev-1"
+              autoFocus
+              autoComplete="username"
+              className="rounded-xl border border-black/[0.08] bg-black/[0.05] px-4 py-3.5 text-[15px] leading-snug text-foreground outline-none placeholder:text-foreground/40 focus:border-foreground/30 dark:border-white/[0.145] dark:bg-white/[0.06] dark:placeholder:text-foreground/30 dark:focus:border-white/30"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="password"
+              className="text-[14px] font-medium text-foreground"
+            >
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="任意の文字列"
+              autoComplete="current-password"
+              className="rounded-xl border border-black/[0.08] bg-black/[0.05] px-4 py-3.5 text-[15px] leading-snug text-foreground outline-none placeholder:text-foreground/40 focus:border-foreground/30 dark:border-white/[0.145] dark:bg-white/[0.06] dark:placeholder:text-foreground/30 dark:focus:border-white/30"
+            />
+          </div>
+          {error && (
+            <p className="text-[14px] text-red-600 dark:text-red-400" role="alert">
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-xl border border-black/[0.08] bg-foreground px-4 py-3 text-[15px] font-medium text-background transition-colors hover:bg-foreground/90 disabled:opacity-50 dark:border-white/[0.145]"
+          >
+            {loading ? "ログイン中…" : "ログイン"}
+          </button>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/apps/fe-app/src/components/app-shell.tsx
+++ b/apps/fe-app/src/components/app-shell.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { useSession } from "@/contexts/session-context";
+
+export function AppShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const { logout } = useSession();
+
+  const showLogout = pathname !== "/login";
+
+  return (
+    <div className="flex min-h-full flex-1 flex-col">
+      {showLogout ? (
+        <header className="sticky top-0 z-50 flex h-12 shrink-0 items-center justify-end border-b border-black/[0.08] bg-background/90 px-4 backdrop-blur-sm dark:border-white/[0.145]">
+          <button
+            type="button"
+            onClick={logout}
+            className="rounded-lg px-3 py-1.5 text-[14px] font-medium text-foreground/70 transition-colors hover:bg-black/[0.05] hover:text-foreground dark:hover:bg-white/[0.06]"
+          >
+            ログアウト
+          </button>
+        </header>
+      ) : null}
+      <div className="flex flex-1 flex-col">{children}</div>
+    </div>
+  );
+}

--- a/apps/fe-app/src/contexts/session-context.tsx
+++ b/apps/fe-app/src/contexts/session-context.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { SessionManager, type Account, type Role } from "@/lib/session-manager";
+
+type SessionContextValue = {
+  userId: string | undefined;
+  email: string | undefined;
+  role: Role | null | undefined;
+  hasRole: (role: Role) => boolean;
+  logout: () => void;
+};
+
+const SessionContext = createContext<SessionContextValue | null>(null);
+
+export function useSession(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error("useSession must be used within SessionProvider");
+  return ctx;
+}
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [account, setAccount] = useState<Account | undefined>(undefined);
+
+  useEffect(() => {
+    const info = SessionManager.getInfo();
+    setAccount(info);
+  }, [pathname]);
+
+  const hasRole = useCallback(
+    (role: Role) => account?.role === role,
+    [account],
+  );
+
+  const logout = useCallback(() => {
+    SessionManager.clearSession();
+    setAccount(undefined);
+    router.push("/login");
+  }, [router]);
+
+  return (
+    <SessionContext.Provider
+      value={{
+        userId: account?.id,
+        email: account?.email,
+        role: account?.role,
+        hasRole,
+        logout,
+      }}
+    >
+      {children}
+    </SessionContext.Provider>
+  );
+}

--- a/apps/fe-app/src/lib/api-client.ts
+++ b/apps/fe-app/src/lib/api-client.ts
@@ -9,6 +9,9 @@
  * 【使い方のイメージ】
  * `apiClient<{ todos: string[] }>("/todos")` のように、パスと返ってくる JSON の形（型）を指定して呼びます。
  */
+import { ForbiddenError, UnauthenticatedError } from "@/lib/errors";
+import { SessionManager } from "@/lib/session-manager";
+
 const baseURL =
   process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? "http://localhost:8000";
 // NEXT_PUBLIC_ で始まる変数だけ、ブラウザ側のコードに埋め込まれます（.env.local などで設定）
@@ -18,17 +21,33 @@ const baseURL =
  * @param url 先頭に / があるパス（例: "/todos"）。無くても内部で付けます。
  * @param init fetch の第2引数（メソッドやヘッダーなど）。GET だけなら省略することが多いです。
  */
-export async function apiClient<T>(url: string, init?: RequestInit): Promise<T> {
+  export async function apiClient<T>(url: string, init?: RequestInit): Promise<T> {
   // 例: baseURL が http://localhost:8000、url が /todos → 実際には http://localhost:8000/todos へアクセス
   const path = url.startsWith("/") ? url : `/${url}`;
+
+  let token: string | undefined;
+  try {
+    token = SessionManager.getToken();
+  } catch {
+    // 未ログイン状態。認証エラーとして throw し、グローバルハンドラへ
+    throw new UnauthenticatedError("No authentication token");
+  }
+
   const res = await fetch(`${baseURL}${path}`, {
     headers: {
       "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...init?.headers,
     },
     ...init,
   });
-  // status が 200 番台以外（404 や 500 など）のときは「失敗」とみなし、呼び出し元でキャッチできるよう投げる
+    // status が 200 番台以外（404 や 500 など）のときは「失敗」とみなし、呼び出し元でキャッチできるよう投げる
+  if (res.status === 401) {
+    throw new UnauthenticatedError(`401 Unauthorized: ${path}`);
+  }
+  if (res.status === 403) {
+    throw new ForbiddenError(`403 Forbidden: ${path}`);
+  }
   if (!res.ok) {
     throw new Error(`API error: ${res.status} ${res.statusText}`);
   }

--- a/apps/fe-app/src/lib/errors.ts
+++ b/apps/fe-app/src/lib/errors.ts
@@ -1,0 +1,15 @@
+export class UnauthenticatedError extends Error {
+  readonly code = "unauthenticated" as const;
+  constructor(message = "Unauthenticated") {
+    super(message);
+    this.name = "UnauthenticatedError";
+  }
+}
+
+export class ForbiddenError extends Error {
+  readonly code = "forbidden" as const;
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}

--- a/apps/fe-app/src/lib/query-client-provider.tsx
+++ b/apps/fe-app/src/lib/query-client-provider.tsx
@@ -1,40 +1,88 @@
-"use client";
-
 /**
  * 【このファイルの役割】
- * 「React Query（@tanstack/react-query）」を画面で使えるようにするラッパーです。
+ * TanStack Query 用の QueryClient をアプリ全体に渡し、データ取得（query）・更新（mutation）が失敗したときの
+ * 共通処理（例: ログイン画面・禁止画面への遷移）を 1 か所にまとめます。
  *
- * 【React Query とは（ざっくり）】
- * サーバーからデータを取ってきたり、読み込み中・エラー・成功の状態を管理したりするためのライブラリです。
- * `useQuery` などのフックを使うには、そのコンポーネントがこのプロバイダの「内側」にある必要があります。
- *
- * 【なぜ "use client" が必要か】
- * layout.tsx はサーバーでも動くコンポーネントですが、React Query はブラウザ上の React の仕組みに依存します。
- * そのため「クライアント専用の部品」としてこのファイルを分け、layout からここを読み込んでいます。
+ * 【api-client.ts との違い】
+ * - api-client.ts … バックエンド（be-app）への HTTP（fetch）、URL・認証ヘッダー・ステータスに応じた例外の出し方。
+ *   バックエンドの「REST API」とのやり取りだけを担当します。
+ * - このファイル … HTTP や fetch は書かない。React Query の「箱」とデフォルト挙動、および失敗時の画面方針だけ。
+ *   api-client が投げたエラー（UnauthenticatedError など）を、ここで受けて router で反応するイメージです。
  */
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useState, type ReactNode } from "react";
+
+// Next.js（App Router）の部品は、最初から「サーバー上で動く」ものと決まっています。
+// このファイルは画面遷移（useRouter）や React のフック（useRef）を使うので、「ブラウザ側で動く部品」にします。
+// その印がファイル先頭の "use client" です。付けないと、useRouterやuseRef などの「ブラウザ用の React / Next の機能」が使えずエラーになります。
+"use client";
+
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useRef, type ReactNode } from "react";
+import { ForbiddenError, UnauthenticatedError } from "@/lib/errors";
 
 /**
- * アプリ全体を包み、その子ども（children）の中で `useQuery` が使えるようにします。
+ * ここで「データ取得・送信が失敗したときの共通処理」を1か所にまとめます。
+ *
+ * - 「データを取る」（useQuery）と「データを送る・変える」（useMutation）では、
+ *   失敗の通知の受け口が別々です。
+ * - 片方だけに処理を書くと、「取る側はログインへ飛ぶのに、送る側は飛ばない」などの抜けが出ます。
+ * - だから両方（queryCache と mutationCache）に、同じ onError を渡します。
+ */
+function makeQueryClient(onError: (error: Error) => void) {
+  return new QueryClient({
+    queryCache: new QueryCache({ onError }),
+    mutationCache: new MutationCache({ onError }),
+    defaultOptions: {
+      queries: {
+        // retry: 失敗したら自動で「もう一度やり直す」設定。
+        // ログイン切れなどは、やり直しても同じ失敗のままなので、無駄に繰り返さないように false にします。
+        retry: false,
+        // refetchOnWindowFocus: 別のタブから戻ったときに自動で取り直す設定。
+        // そのたびにまた失敗して、ログイン画面へ飛ばす処理が何度も走りやすいので false にします。
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+/**
+ * アプリ全体の「失敗したらどの画面へ行くか」を、ここ1つに集めます。
+ * （実際に「ログイン切れ」などのエラーを投げるのは api-client 側のイメージです）
  */
 export function QueryClientProviderWrapper({ children }: { children: ReactNode }) {
-  // QueryClient は「設定やキャッシュを持つ箱」。1つのアプリで同じ箱を使い回す必要がある
-  // useState( () => ... ) の形にすると、最初の1回だけ作られ、再描画のたびに新しく作り直されない
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            // 失敗しても自動で何度も再試行しない（挙動が分かりやすい）
-            retry: false,
-            // 別タブから戻ってきたときに、勝手にデータを取り直さない
-            refetchOnWindowFocus: false,
-          },
-        },
-      }),
-  );
+  // コードから「/login へ行く」などの画面遷移をするための道具です（<Link> をクリックするのに近い）。
+  const router = useRouter();
+  // エラーが短い時間に複数まとめて来たとき、router.push が何度も続かないようにするための「いま処理中」フラグです。
+  const isHandling = useRef(false);
 
-  // 下の子コンポーネントに queryClient を渡す（これが無いと useQuery がエラーになる）
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  const handleError = (error: Error) => {
+    // 複数の query が同時に失敗したり、query の直後に mutation が失敗したりすると、onError が短時間に何度も呼ばれる。
+    // そのたびに router.push まで走ると連打になるので、ここで最初の1回だけ通す。
+    if (isHandling.current) return;
+    isHandling.current = true;
+
+    // エラーが「ログイン切れ」か「権限なし」かを、名前付きの型で判定します。
+    // 数字のステータスコードだけだと、読み手が意味を取り違えやすいので、型で意図をはっきりさせます。
+    if (error instanceof UnauthenticatedError) {
+      router.push("/login");
+    } else if (error instanceof ForbiddenError) {
+      router.push("/forbidden");
+    }
+
+    // 少し待ってから「処理中」を終了に戻します。
+    // これがないと、最初の1回だけ遷移して、その後ずっとエラーを無視し続ける可能性があります。
+    setTimeout(() => {
+      isHandling.current = false;
+    }, 0);
+  };
+
+  // QueryClient は「取得したデータを覚えておく箱」です。
+  // 画面が更新されるたびに新しい箱を作ると、中身が消えたり、通信の状態がおかしくなります。
+  // だから最初の1回だけ作って、ずっと同じ箱を使い回します（useRef で作り直されないようにしています）。
+  const [queryClient] = useRef([makeQueryClient(handleError)]).current;
+
+  return (
+    // この中に書かれた画面（children）が、同じ QueryClient（同じ箱）を共有できるようにします。
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
 }

--- a/apps/fe-app/src/lib/session-manager.ts
+++ b/apps/fe-app/src/lib/session-manager.ts
@@ -1,0 +1,49 @@
+/** バックエンド Role enum の value と一致 */
+export type Role = "admin" | "teacher" | "student" | "hr";
+
+export type Account = {
+  id: string;
+  email: string;
+  role: Role | null;
+};
+
+const TOKEN_KEY = "mock_auth_token";
+const USER_INFO_KEY = "mock_user_info";
+
+export const SessionManager = {
+  getToken(): string {
+    const token = localStorage.getItem(TOKEN_KEY);
+    if (!token) throw new Error("No authentication token found");
+    return token;
+  },
+
+  getInfo(): Account | undefined {
+    const raw = localStorage.getItem(USER_INFO_KEY);
+    if (!raw) return undefined;
+    return JSON.parse(raw) as Account;
+  },
+
+  isSignedIn(): boolean {
+    return !!localStorage.getItem(TOKEN_KEY);
+  },
+
+  setAuthentication(userId: string, account: Account): void {
+    localStorage.setItem(TOKEN_KEY, userId);
+    localStorage.setItem(USER_INFO_KEY, JSON.stringify(account));
+  },
+
+  /** トークンとユーザー情報のみ削除（画面遷移は呼び出し側で行う） */
+  clearSession(): void {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_INFO_KEY);
+  },
+
+  logout(returnTo?: string): void {
+    SessionManager.clearSession();
+    if (returnTo) {
+      window.location.href = returnTo;
+    } else {
+      window.location.reload();
+    }
+  },
+};


### PR DESCRIPTION
## 概要
home_office_essentialsのbe-appのモック認証を、prj-dia3のモック認証に近い考え方に揃えました。Bearerトークンを外部ユーザーIDとしてJSONからユーザーを解決し、トークン文字列のキーワードでロールを推論します。フロントはその仕様に合わせてトークン保持と型、READMEを更新しています。

## 背景・目的
従来はBearerをそのままuser_idとして扱い、adminの有無だけでUSER/ADMINを付けていました。ローカル検証を業務ロールに近い形にしたい、外部IDと内部IDを分けたい、という意図で変更しています。

## be-appの変更内容
- 設定: mock_users_pathを追加し、デフォルトはdata/mock_users.json。環境変数MOCK_USERS_PATHで上書き可能。
- 永続: MockUserFileGatewayがexternal_user_idとBearerを完全一致で照合し、Userのid/emailを返す。
- 認証: MockAuthUseCaseがIUserGatewayに依存。トークンから_ROLE_KEYWORDS相当でロールを1つまたは空配列にし、ゲートウェイでユーザーを引いてからAuthUseCaseOutputを返す。
- ロール: RoleをADMIN/TEACHER/STUDENT/HRに整理（旧USERは廃止）。
- 認可: /todosは@require_role(list(Role))のため、ロールが空のユーザーは403（/meは通るがroleはnullになり得る）。
- DI: config.py→main.pyのfrom_dict→container.pyのGateways.user/UseCases.authにパスと依存を流し、app.state.auth_usecaseに組み立て済みのMockAuthUseCaseを載せる。
- README: 認証・認可・ロールとエンドポイント表、環境変数、ディレクトリ説明を追記・更新。

## fe-appの変更内容
- セッション: BearerはログインフォームのユーザーID（=be-appのexternal_user_id）のまま保持。/me成功後にid/email/roleをサーバ値で上書き。
- 型: Roleをbe-appの列挙valueに合わせ、roleはnull許容。
- README: フロント側の責務（トークン付与、401/403、Query共通遷移など）を記載。

## 使い方の注意（レビュー・動作確認向け）
- ログインに使う文字列は**apps/be-app/data/mock_users.jsonのexternal_user_id**と一致させる必要がある（例teacher-dev-1）。studentだけなどでは401になる。
- CORS: CORS_ORIGINSはlist[str]用にJSON配列で書くのが安全（README参照）。

## 影響範囲
- 既存の「任意の文字列＋adminでADMIN」というモック挙動は破壊的変更。
- plain-dev-1のようにユーザーは存在してもキーワードが無いとロール空→/todosは403。